### PR TITLE
- Patch Off-By-One bug in extract_osc_address()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,11 @@ fn extract_osc_address(buf: &[u8], ix: &mut usize) -> Result<String, ParserError
 
     let mut address = String::new();
 
-    while *ix <= buf.len() && buf[*ix] != 0 { // *ix >= buf.len() // Cheers sutekh!
+    /*
+     * Patching OBO bug
+     * ~ Sutekh
+     */
+    while *ix <= buf.len()-1 && buf[*ix] != 0 { // *ix >= buf.len() // Cheers sutekh!
         address.push(buf[*ix] as char);
         *ix += 1;
     }


### PR DESCRIPTION
Patching an OBO bug in extract_osc_address()

The length of the buffer was being incorrectly used to iterate through the buffer's bytes and causing an OOR causing a crash.